### PR TITLE
Replaced getDOMNode() with React.findDOMNode()

### DIFF
--- a/react-swipe.js
+++ b/react-swipe.js
@@ -47,7 +47,7 @@
 
     componentDidMount: function () {
       if (this.isMounted()) {
-        this.swipe = Swipe(this.getDOMNode(), this.props);
+        this.swipe = Swipe(React.findDOMNode(this), this.props);
       }
     },
 


### PR DESCRIPTION
getDOMNode() is deprecated: https://facebook.github.io/react/docs/component-api.html#getdomnode